### PR TITLE
Migrating from BasePlugin module accroding the documentation

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -1,6 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
-
---local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 local responses = kong.response
@@ -12,63 +9,55 @@ local ngx_log = ngx.log
 local policy_ALL = 'all'
 local policy_ANY = 'any'
 
-local JWTAuthHandler = BasePlugin:extend()
-
-
-JWTAuthHandler.PRIORITY = 950
-JWTAuthHandler.VERSION = "0.1.0"
-
-
-function JWTAuthHandler:new()
-  JWTAuthHandler.super.new(self, "jwt-auth")
-end
+local JWTAuthHandler = {
+    VERSION = "0.4.0",
+    PRIORITY = 950
+}
 
 --- Filter a table
 -- @param filterFnc (function) filter function
 -- @return (table) the filtered table 
 function table:filter(filterFnc)
-  local result = {}
+    local result = {}
 
-  for k, v in ipairs(self) do
-      if filterFnc(v, k, self) then
-          table.insert(result, v)
-      end
-  end
+    for k, v in ipairs(self) do
+        if filterFnc(v, k, self) then
+            table.insert(result, v)
+        end
+    end
 
-  return result
+    return result
 end
 
 --- Get index of a value at a table.
 -- @param any value
 -- @return any
 function table:find(value)
-  for k, v in ipairs(self) do
-      if v == value then
-          return k
-      end
-  end
+    for k, v in ipairs(self) do
+        if v == value then
+            return k
+        end
+    end
 end
-
 
 --- checks wheter all given roles are also present in the claimed roles
 -- @param roles_to_check (array) an array of role names
 -- @param claimed_roles (table) list of roles claimed in JWT
 -- @return (boolean) true if all given roles are also in the claimed roles
 local function all_roles_in_roles_claim(roles_to_check, claimed_roles)
-  local result = false
-  local diff
+    local result = false
+    local diff
 
-  diff = table.filter(roles_to_check, function(value)
-           return not table.find(claimed_roles, value)
-         end)
+    diff = table.filter(roles_to_check, function(value)
+        return not table.find(claimed_roles, value)
+    end)
 
-  if #diff == 0 then
-    result = true
-  end
+    if #diff == 0 then
+        result = true
+    end
 
-  return result
+    return result
 end
-
 
 --- checks whether a claimed role is part of a given list of roles.
 -- @param roles_to_check (array) an array of role names.
@@ -76,20 +65,20 @@ end
 -- @return (boolean) whether a claimed role is part of any of the given roles.
 
 local function role_in_roles_claim(roles_to_check, claimed_roles)
-  local result = false
-  for _, role_to_check in ipairs(roles_to_check) do
-    for _, role in ipairs(claimed_roles) do
-      if role == role_to_check then
-        result = true
-        break
-      end
+    local result = false
+    for _, role_to_check in ipairs(roles_to_check) do
+        for _, role in ipairs(claimed_roles) do
+            if role == role_to_check then
+                result = true
+                break
+            end
+        end
+        if result then
+            break
+        end
     end
-    if result then
-      break
-    end
-  end
-  
-  return result
+
+    return result
 end
 
 --- split a string into substrings by reparator
@@ -97,98 +86,100 @@ end
 -- @param sep (string) single character string (!) to separate on
 -- @return (table) list of separated parts
 local function split(str, sep)
-  local ret = {}
-  local n=1
-  for w in str:gmatch("([^"..sep.."]*)") do
-     ret[n] = ret[n] or w:gsub("^%s*(.-)%s*$", "%1") -- strip whitespace
-     if w ~= "" then
-      ret[n] = w
-      n = n + 1
-     end
-  end
-  return ret
+    local ret = {}
+    local n = 1
+    for w in str:gmatch("([^" .. sep .. "]*)") do
+        ret[n] = ret[n] or w:gsub("^%s*(.-)%s*$", "%1") -- strip whitespace
+        if w ~= "" then
+            ret[n] = w
+            n = n + 1
+        end
+    end
+    return ret
 end
 
-
 function JWTAuthHandler:access(conf)
-  JWTAuthHandler.super.access(self)
+    JWTAuthHandler.super.access(self)
 
-  -- get the JWT from the Nginx context
-  local token = ngx.ctx.authenticated_jwt_token
-  if not token then
-    ngx_log(ngx_error, "[jwt-auth plugin] Cannot get JWT token, add the ",
-                       "JWT plugin to be able to use the JWT-Auth plugin")
-                       return kong.response.exit(403, {
-                        message = "You cannot consume this service"
-                      })
-    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
-  end
-
-  -- decode token to get roles claim
-  local jwt, err = jwt_decoder:new(token)
-  if err then
-    -- return false, {status = 401, message = "Bad token; " .. tostring(err)}
-    return kong.response.exit(401, { message = "Bad token; " .. tostring(err)})
-  end
-  
-  local msg_error_all = conf.msg_error_all
-  
-  local msg_error_any = conf.msg_error_any
-  local msg_error_not_roles_claimed = conf.msg_error_not_roles_claimed
-  local roles_cfg = conf.roles
-  local claims = jwt.claims
-  local roles = claims[conf.roles_claim_name]
-  local roles_table = {}
-
-  -- check if no roles claimed..
-  if not roles then
-    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
-    return kong.response.exit(403, {
-      -- message = "You cannot consume this service"
-      message = msg_error_not_roles_claimed
-    })
-  end
-
-
-  -- if the claim is a string (single role), make it a table
-  if type(roles) == "string" then
-    if string.find(roles, ",") then
-      roles_table = split(roles, ",")
-
-    else
-      table.insert(roles_table, roles)
- 
+    -- get the JWT from the Nginx context
+    local token = ngx.ctx.authenticated_jwt_token
+    if not token then
+        ngx_log(ngx_error, "[jwt-auth plugin] Cannot get JWT token, add the ",
+            "JWT plugin to be able to use the JWT-Auth plugin")
+        return kong.response.exit(403, {
+            message = "You cannot consume this service"
+        })
+        -- return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
     end
-    roles = roles_table
-  end
-  if type(conf.roles) == "table" then
-  -- in declarative db-less setup the roles can be separated by a space
-  if string.find(conf.roles[1], " ") then
-  conf_roles_table = split(conf.roles[1], " ")
-  end
-  if string.find(conf.roles[1], ",") then
-  conf_roles_table = split(conf.roles[1], ",")
-  end
-  conf.roles = conf_roles_table
-  end
-  if conf.policy == policy_ANY and not role_in_roles_claim(conf.roles, roles) then
-    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
-    return kong.response.exit(403, {
-      -- message = "You can't use these service"
-      detail = "The permitted role for this invocation is [" .. table.concat(roles_cfg,", ") .. "] and yours role are [" .. table.concat(roles,", ").."]",
-      message = msg_error_any
 
-    })
-  end
+    -- decode token to get roles claim
+    local jwt, err = jwt_decoder:new(token)
+    if err then
+        -- return false, {status = 401, message = "Bad token; " .. tostring(err)}
+        return kong.response.exit(401, {
+            message = "Bad token; " .. tostring(err)
+        })
+    end
 
-  if conf.policy == policy_ALL and not all_roles_in_roles_claim(conf.roles, roles) then
-    --return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
-    return kong.response.exit(403, {
-      -- message = "You can't use these service"
-      detail = "The permitted role for this invocation is [" .. table.concat(roles_cfg,", ") .. "] and yours role are [" .. table.concat(roles,", ").."]",
-      message = msg_error_all
-    })
-  end
+    local msg_error_all = conf.msg_error_all
+
+    local msg_error_any = conf.msg_error_any
+    local msg_error_not_roles_claimed = conf.msg_error_not_roles_claimed
+    local roles_cfg = conf.roles
+    local claims = jwt.claims
+    local roles = claims[conf.roles_claim_name]
+    local roles_table = {}
+
+    -- check if no roles claimed..
+    if not roles then
+        -- return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+        return kong.response.exit(403, {
+            -- message = "You cannot consume this service"
+            message = msg_error_not_roles_claimed
+        })
+    end
+
+    -- if the claim is a string (single role), make it a table
+    if type(roles) == "string" then
+        if string.find(roles, ",") then
+            roles_table = split(roles, ",")
+
+        else
+            table.insert(roles_table, roles)
+
+        end
+        roles = roles_table
+    end
+    if type(conf.roles) == "table" then
+        -- in declarative db-less setup the roles can be separated by a space
+        if string.find(conf.roles[1], " ") then
+            conf_roles_table = split(conf.roles[1], " ")
+        end
+        if string.find(conf.roles[1], ",") then
+            conf_roles_table = split(conf.roles[1], ",")
+        end
+        conf.roles = conf_roles_table
+    end
+    if conf.policy == policy_ANY and not role_in_roles_claim(conf.roles, roles) then
+        -- return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+        return kong.response.exit(403, {
+            -- message = "You can't use these service"
+            detail = "The permitted role for this invocation is [" .. table.concat(roles_cfg, ", ") ..
+                "] and yours role are [" .. table.concat(roles, ", ") .. "]",
+            message = msg_error_any
+
+        })
+    end
+
+    if conf.policy == policy_ALL and not all_roles_in_roles_claim(conf.roles, roles) then
+        -- return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+        return kong.response.exit(403, {
+            -- message = "You can't use these service"
+            detail = "The permitted role for this invocation is [" .. table.concat(roles_cfg, ", ") ..
+                "] and yours role are [" .. table.concat(roles, ", ") .. "]",
+            message = msg_error_all
+        })
+    end
 
 end
 

--- a/schema.lua
+++ b/schema.lua
@@ -1,11 +1,57 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
-  no_consumer = true,
-  fields = {
-    roles = {type = "array", default = {}},
-    roles_claim_name = {type = "string", default = "roles"},
-    msg_error_any = {type = "string", default = "To be able to use this service you must have at least one of the roles configured"},
-    msg_error_all = {type = "string", default = "In order to use this service you must match all the roles configured with the associated ones in the JWT token"},
-    msg_error_not_roles_claimed = {type = "string", default = "The claim roles are not informed in the JWT token"},
-    policy = {type = "string", default = "any", enum = {"any", "all"}}
-  }
+    name = "jwt-auth-rbac",
+    fields = {
+        {
+            -- this plugin will only be applied to services or routes
+            consumer = typedefs.no_consumer
+        },
+        {
+            -- this plugin will only run within nginx http module
+            protocols = typedefs.protocols_http
+        },
+        {
+            config = {
+                type = "record",
+                fields = {{
+                    roles = {
+                        type = "array",
+                        elements = {
+                            type = "string"
+                        }
+                    }
+                }, {
+                    roles_claim_name = {
+                        type = "string",
+                        default = "roles"
+                    }
+                }, {
+                    msg_error_any = {
+                        type = "string",
+                        default = "To be able to use this service you must have at least one of the roles configured"
+                    }
+                }, {
+                    msg_error_all = {
+                        type = "string",
+                        default = "In order to use this service you must match all the roles configured with the associated ones in the JWT token"
+                    }
+                }, {
+                    msg_error_not_roles_claimed = {
+                        type = "string",
+                        default = "The claim roles are not informed in the JWT token"
+                    }
+                }, {
+                    policy = {
+                        type = "string",
+                        default = "any",
+                        one_of = {"any", "all"}
+                    }
+                }}
+            }
+        },
+        entity_checks = {{
+            at_least_one_of = {"config.roles"}
+        }}
+    }
 }


### PR DESCRIPTION
Based on the information on the official docs:

- [https://docs.konghq.com/gateway/latest/plugin-development/custom-logic/#migrating-from-baseplugin-module](https://github.com/prabago/kong-plugin-jwt-auth-rbac/pull/url)
- [https://docs.konghq.com/gateway/latest/plugin-development/configuration/#describing-your-configuration-schema](https://github.com/prabago/kong-plugin-jwt-auth-rbac/pull/url)

we modified the plugin to be compatible with the current kong release.